### PR TITLE
feat: migrate routines to template repo

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Dumbbell, Timer as TimerIcon, History, Settings as SettingsIcon, Play, Square, Plus, Trash2, Edit3, Download, Upload, ChevronRight, ChevronLeft, BarChart3, Flame, Repeat2, Check, Award, Clock } from "lucide-react";
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, BarChart, Bar, CartesianGrid, Legend, PieChart, Pie, Cell } from "recharts";
+import { migrateToTemplates } from "./lib/migrations.js";
 
 // =====================================
 // NicoFit — single-file React app (v1.6)
@@ -93,7 +94,7 @@ const GROUP_COLORS = { pecho:'#EF4444', espalda:'#3B82F6', pierna:'#10B981', hom
 
 // ---------- Default dataset (pre-cargada con Rutina 1) ----------
 const DEFAULT_DATA = {
-  version: 4,
+  version: 5,
   settings: {
     unit: "kg", // "kg" | "lb"
     defaultRestSec: 90,
@@ -160,11 +161,13 @@ const DEFAULT_DATA = {
   ],
   sessions: [], // strength + cardio
   profileByExerciseId: {},
+  userRoutinesIndex: {},
+  customExercisesById: {},
 };
 
 // ---------- Storage ----------
-const LS_KEY = "nicofit_data_v4";
-const load = () => {
+const LS_KEY = "nicofit_data_v5";
+const loadFromLS = () => {
   try {
     const raw = localStorage.getItem(LS_KEY);
     const parsed = raw ? JSON.parse(raw) : DEFAULT_DATA;
@@ -237,7 +240,10 @@ const TABS = [
 
 // ---------- Main App ----------
 export default function App() {
-  const [data, setData] = useState(load());
+const [data, setData] = useState(() => {
+  const raw = loadFromLS();
+  return migrateToTemplates(raw);
+});
   const [tab, setTab] = useState("today");
   const [activeSession, setActiveSession] = useState(null); // {id,type,dateISO,routineId,sets:[],startedAt,kcal?}
   const [restSec, setRestSec] = useState(0);

--- a/src/lib/__tests__/repoAdapter.smoke.test.js
+++ b/src/lib/__tests__/repoAdapter.smoke.test.js
@@ -1,0 +1,27 @@
+import { getTemplateRoutineKeys, getTemplateExercises } from '../repoAdapter.js';
+import { migrateToTemplates } from '../migrations.js';
+
+const keys = getTemplateRoutineKeys();
+console.assert(Array.isArray(keys) && keys.length > 0, 'getTemplateRoutineKeys should return >0 keys');
+
+const exs = getTemplateExercises(keys[0]);
+console.assert(exs.every(e => e && e.fixed), 'getTemplateExercises should return exercises with fixed');
+
+const prev = {
+  routines: [
+    { name: 'Test', exercises: [
+      { name: 'Belt squat cuádriceps', mode: 'reps', targetSets: 1, targetReps: 8 },
+      { name: 'Movimiento misterioso', mode: 'reps', targetSets: 1, targetReps: 10 }
+    ] }
+  ],
+  sessions: [],
+  profileByExerciseId: {}
+};
+const migrated = migrateToTemplates(prev);
+const firstKey = Object.keys(migrated.userRoutinesIndex)[0];
+const ids = migrated.userRoutinesIndex[firstKey];
+console.assert(ids.length === 2, 'migration should map two exercises');
+console.assert(ids.some(id => id.startsWith('custom/')), 'migration should create a custom exercise');
+console.assert(Object.keys(migrated.customExercisesById).length === 1, 'customExercisesById should contain one entry');
+
+console.log('repoAdapter smoke tests passed');

--- a/src/lib/exerciseResolver.js
+++ b/src/lib/exerciseResolver.js
@@ -1,0 +1,5 @@
+import { getExerciseById } from './repoAdapter.js';
+
+export function resolveExercise(id, customExercisesById) {
+  return customExercisesById?.[id] || getExerciseById(id) || null;
+}

--- a/src/lib/migrations.js
+++ b/src/lib/migrations.js
@@ -1,0 +1,83 @@
+import repo from '../data/exercisesRepo.json' with { type: 'json' };
+import { getTemplateRoutineKeys, normalizeName } from './repoAdapter.js';
+
+function simpleHash(str) {
+  let h = 0;
+  for (let i = 0; i < str.length; i++) {
+    h = Math.imul(31, h) + str.charCodeAt(i) | 0;
+  }
+  return Math.abs(h).toString(36);
+}
+
+function inferMuscles(name = '') {
+  const n = normalizeName(name);
+  if (/(pecho|press banca|apertura)/.test(n)) return ['pecho'];
+  if (/(espalda|remo|jalon|pull)/.test(n)) return ['espalda'];
+  if (/(pierna|squat|peso muerto|zancada|cuadriceps|gluteo)/.test(n)) return ['pierna'];
+  if (/(hombro|militar|lateral|rear delt|face pull)/.test(n)) return ['hombro'];
+  if (/(biceps|curl)/.test(n)) return ['brazo'];
+  if (/(triceps|overhead|barra)/.test(n)) return ['brazo'];
+  if (/(core|abs|plancha|rueda|paloff|woodchopper|elevacion piernas)/.test(n)) return ['core'];
+  return [];
+}
+
+export function migrateToTemplates(prevData = {}) {
+  const data = { ...prevData };
+  data.customExercisesById = data.customExercisesById || {};
+  data.profileByExerciseId = data.profileByExerciseId || {};
+
+  const allRepoExercises = Object.values(repo.byId || {});
+  const findMatchId = (name) => {
+    const norm = normalizeName(name);
+    for (const ex of allRepoExercises) {
+      const n = normalizeName(ex.name);
+      if (n === norm || n.includes(norm) || norm.includes(n)) return ex.id;
+    }
+    return null;
+  };
+
+  if (!data.userRoutinesIndex && Array.isArray(data.routines)) {
+    const templateKeys = getTemplateRoutineKeys();
+    data.userRoutinesIndex = {};
+    templateKeys.forEach(k => { data.userRoutinesIndex[k] = []; });
+
+    data.routines.forEach((r, idx) => {
+      const key = templateKeys[idx] || `custom_${idx}`;
+      data.userRoutinesIndex[key] = data.userRoutinesIndex[key] || [];
+      (r.exercises || []).forEach(oldEx => {
+        const matchId = findMatchId(oldEx.name);
+        if (matchId) {
+          data.userRoutinesIndex[key].push(matchId);
+        } else {
+          const id = `custom/${simpleHash(oldEx.name)}`;
+          data.customExercisesById[id] = {
+            id,
+            name: oldEx.name,
+            muscles: inferMuscles(oldEx.name),
+            mode: oldEx.mode,
+            fixed: {
+              targetSets: oldEx.targetSets,
+              targetRepsRange: oldEx.targetRepsRange || (oldEx.targetReps ? String(oldEx.targetReps) : undefined),
+              targetTimeSec: oldEx.targetTimeSec,
+              restSec: oldEx.restSec,
+            },
+            setup: oldEx.setup,
+            notes: oldEx.notes,
+          };
+          data.userRoutinesIndex[key].push(id);
+        }
+      });
+    });
+    data.version = 5;
+  }
+
+  if (data.userRoutinesIndex) {
+    const validRepoIds = new Set(allRepoExercises.map(ex => ex.id));
+    Object.keys(data.userRoutinesIndex).forEach(key => {
+      const arr = data.userRoutinesIndex[key] || [];
+      data.userRoutinesIndex[key] = arr.filter(id => data.customExercisesById[id] || validRepoIds.has(id));
+    });
+  }
+
+  return data;
+}

--- a/src/lib/repo.js
+++ b/src/lib/repo.js
@@ -1,4 +1,4 @@
-import repoJson from '../data/exercisesRepo.json';
+import repoJson from '../data/exercisesRepo.json' with { type: 'json' };
 
 /**
  * Load the exercises repository.

--- a/src/lib/repoAdapter.js
+++ b/src/lib/repoAdapter.js
@@ -1,0 +1,32 @@
+import repo from '../data/exercisesRepo.json' with { type: 'json' };
+import { loadRepo, getExercise, listRoutine, primaryGroup, findAlternatives } from '../lib/repo.js';
+export { primaryGroup, loadRepo };
+
+export function getTemplateRoutineKeys() {
+  return Object.keys(repo.routinesIndex || {});
+}
+
+export function getTemplateRoutineName(key) {
+  return repo.meta?.routineNames?.[key] || key;
+}
+
+export function getTemplateExercises(key) {
+  return listRoutine(repo, repo.routinesIndex, key);
+}
+
+export function getExerciseById(id) {
+  return getExercise(repo, id);
+}
+
+export function suggestAlternativesByExerciseId(id) {
+  const ex = getExerciseById(id);
+  if (!ex) return [];
+  return findAlternatives(repo, { muscles: ex.muscles, implement: ex.implement }).filter(e => e.id !== id);
+}
+
+export function normalizeName(s) {
+  return String(s || '')
+    .toLowerCase()
+    .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
+    .replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
## Summary
- adapt repo utils with helper functions and name normalizer
- migrate legacy routines into template-based index with custom exercise support
- add resolver helper and basic smoke tests

## Testing
- `node src/lib/__tests__/repoAdapter.smoke.test.js`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a46efe80e8832fa33f7098f9a14c5e