### PR TITLE
refactor: user routine index with custom exercises

### DIFF
--- a/src/lib/exerciseResolver.js
+++ b/src/lib/exerciseResolver.js
@@ -1,5 +1,17 @@
 import { getExerciseById } from './repoAdapter.js';
 
 export function resolveExercise(id, customExercisesById) {
-  return customExercisesById?.[id] || getExerciseById(id) || null;
+  const raw = customExercisesById?.[id] || getExerciseById(id);
+  if (!raw) return null;
+  const { fixed = {}, setup = {}, ...rest } = raw;
+  return {
+    ...rest,
+    targetSets: fixed.targetSets,
+    targetRepsRange: fixed.targetRepsRange,
+    targetTimeSec: fixed.targetTimeSec,
+    restSec: fixed.restSec,
+    pulleyHeightMark: setup.pulleyHeightMark,
+    benchAngleDeg: setup.benchAngleDeg,
+    seatHeightMark: setup.seatHeightMark,
+  };
 }


### PR DESCRIPTION
## Summary
- store routines by id in `userRoutinesIndex` with optional custom names
- load exercises via ids resolving repo/custom data and show session suggestions
- migrate history analytics to resolve primary muscle groups

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a470d7fd38832f8c9b9feed031d597