### PR TITLE
feat: seed user routines index

### DIFF
--- a/src/lib/defaultUserRoutines.js
+++ b/src/lib/defaultUserRoutines.js
@@ -1,0 +1,12 @@
+import repo from '../data/exercisesRepo.json' with { type: 'json' };
+
+/**
+ * Devuelve un objeto { [routineKey]: string[] } clonado desde repo.routinesIndex.
+ * Si no hay routinesIndex, retorna {}.
+ */
+export function buildDefaultUserRoutinesIndex() {
+  const idx = repo?.routinesIndex || {};
+  const out = {};
+  for (const k of Object.keys(idx)) out[k] = [...(idx[k] || [])];
+  return out;
+}


### PR DESCRIPTION
## Summary
- add helper to clone repo routines into a user index
- seed user routines, custom exercises and version if missing during app init

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4ef6d4770832f82a79b2dad0e485a