### PR TITLE
feat: improve exercise initialization and alternatives

### DIFF
--- a/src/lib/repoAdapter.js
+++ b/src/lib/repoAdapter.js
@@ -1,6 +1,6 @@
 import repo from '../data/exercisesRepo.json' with { type: 'json' };
 import { loadRepo, getExercise, listRoutine, primaryGroup, findAlternatives } from '../lib/repo.js';
-export { primaryGroup, loadRepo };
+export { primaryGroup, loadRepo, findAlternatives };
 
 export function getTemplateRoutineKeys() {
   return Object.keys(repo.routinesIndex || {});

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,0 +1,33 @@
+export const roundToNearest = (val, step = 1) => Math.round(val / step) * step;
+
+export function getLastUsedSetForExercise(exId, sessions = []) {
+  const sorted = [...(sessions || [])]
+    .filter((s) => s.type === 'strength')
+    .sort((a, b) => new Date(b.dateISO) - new Date(a.dateISO));
+  for (const sess of sorted) {
+    const sets = (sess.sets || []).filter(
+      (st) => st.exerciseId === exId && st.mode === 'reps' && st.weightKg > 0
+    );
+    if (sets.length) {
+      const last = sets[sets.length - 1];
+      return { weightKg: last.weightKg, reps: last.reps, rir: last.rir, dateISO: sess.dateISO };
+    }
+  }
+  return null;
+}
+
+export function getInitialWeightForExercise(exId, data, repo) {
+  const prof = data?.profileByExerciseId?.[exId];
+  let weight = prof?.next?.weightKg;
+  if (weight == null) weight = prof?.last?.weightKg;
+  if (weight == null) {
+    const last = getLastUsedSetForExercise(exId, data?.sessions);
+    weight = last?.weightKg;
+  }
+  if (weight == null) {
+    const ex = repo?.byId?.[exId];
+    weight = ex?.defaults?.initialWeightKg ?? ex?.fixed?.minimumWeightKg;
+  }
+  weight = weight ?? 0;
+  return roundToNearest(weight, 0.25);
+}


### PR DESCRIPTION
## Summary
- seed initial weights from profile history and repo defaults
- allow per-session exercise overrides with immediate replacement
- add muscle-group selection when inserting exercises and align footer buttons

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4f87725dc832f84cc3e3399850d46