### PR TITLE
Handle routine default weights and exercise overrides

### DIFF
--- a/src/lib/repoAdapter.js
+++ b/src/lib/repoAdapter.js
@@ -1,6 +1,21 @@
-import repo from '../data/exercisesRepo.json' with { type: 'json' };
+import repo from '../data/exercisesRepo.json';
 import { loadRepo, getExercise, listRoutine, primaryGroup, findAlternatives } from '../lib/repo.js';
 export { primaryGroup, loadRepo, findAlternatives };
+
+export function getRoutineBaseDefaults(routineKey, exId) {
+  const r1 = repo?.routineDefaults?.[routineKey]?.[exId]?.initialWeightKg;
+  const r2 = repo?.routinesDetail?.[routineKey]?.[exId]?.initialWeightKg;
+  const r3 = repo?.byId?.[exId]?.defaults?.initialWeightKg;
+  return (Number.isFinite(r1) ? r1 : Number.isFinite(r2) ? r2 : (Number.isFinite(r3) ? r3 : undefined));
+}
+
+export function getExerciseDefaults(exId) {
+  const e = repo?.byId?.[exId] || {};
+  return {
+    initialWeightKg: Number.isFinite(e?.defaults?.initialWeightKg) ? e.defaults.initialWeightKg : undefined,
+    minimumWeightKg: Number.isFinite(e?.fixed?.minimumWeightKg) ? e.fixed.minimumWeightKg : undefined,
+  };
+}
 
 export function getTemplateRoutineKeys() {
   return Object.keys(repo.routinesIndex || {});


### PR DESCRIPTION
## Summary
- add adapter helpers to pull initial and minimum weights from routine/exercise defaults
- prioritize profile, routine, history and exercise defaults when choosing starting weight
- initialize session state by routine slot, supporting immediate alternative replacements and correct IDs when registering sets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a62c9c2218832f94b6a07a25e709ed