### PR TITLE
feat: improve default weight and alternative handling

### DIFF
--- a/src/lib/repoAdapter.js
+++ b/src/lib/repoAdapter.js
@@ -3,28 +3,18 @@ import { loadRepo, getExercise, listRoutine, primaryGroup, findAlternatives } fr
 export { primaryGroup, loadRepo, findAlternatives };
 
 export function getRoutineBaseDefaults(routineKey, exId) {
-  const cands = [
-    repo?.routineDefaults?.[routineKey]?.[exId]?.initialWeightKg,
-    repo?.routinesDetail?.[routineKey]?.[exId]?.initialWeightKg,
-    repo?.routinesDetail?.[routineKey]?.[exId]?.weightKg,
-    repo?.routinesDetail?.[routineKey]?.[exId]?.pesoKg,
-    repo?.byId?.[exId]?.defaults?.initialWeightKg,
-    repo?.byId?.[exId]?.fixed?.suggestedWeightKg,
-    repo?.byId?.[exId]?.suggestedWeightKg,
-  ];
-  for (const v of cands) if (Number.isFinite(v)) return v;
-  return undefined;
+  // In exercisesRepo.json there are no routineDefaults; use per-exercise base
+  const w = repo?.byId?.[exId]?.initialRecord?.weightKg;
+  return Number.isFinite(w) ? w : undefined;
 }
 
 export function getExerciseDefaults(exId) {
   const e = repo?.byId?.[exId] || {};
-  const a = e?.defaults?.initialWeightKg;
-  const b = e?.fixed?.minimumWeightKg;
-  return {
-    initialWeightKg: Number.isFinite(a) ? a : undefined,
-    minimumWeightKg: Number.isFinite(b) ? b : undefined,
-  };
+  const w = e?.initialRecord?.weightKg;
+  return { initialWeightKg: Number.isFinite(w) ? w : undefined };
 }
+
+export function getRepo() { return repo; }
 
 export function listMuscleGroups() {
   const set = new Set();

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -2,39 +2,41 @@ import { getRoutineBaseDefaults, getExerciseDefaults } from './repoAdapter.js';
 
 export const roundToNearest = (val, step = 1) => Math.round(val / step) * step;
 
-export function getLastUsedSetForExercise(exId, sessions) {
-  for (let i = 0; i < (sessions?.length || 0); i++) {
+export function round025(x) { return Math.round(x / 0.25) * 0.25; }
+
+export function getLastUsedSetForExercise(exId, sessions = []) {
+  for (let i = 0; i < sessions.length; i++) {
     const s = sessions[i];
     if (s?.type !== 'strength') continue;
-    const sets = Array.isArray(s.sets) ? [...s.sets].reverse() : [];
-    for (const st of sets) {
-      if (st.exerciseId === exId && st.mode !== 'time' && Number.isFinite(st.weightKg) && st.weightKg > 0) {
-        return st;
-      }
+    const arr = Array.isArray(s.sets) ? [...s.sets].reverse() : [];
+    for (const st of arr) {
+      if (st.exerciseId === exId && st.mode !== 'time' && Number.isFinite(st.weightKg) && st.weightKg > 0) return st;
     }
   }
   return null;
 }
 
-export function round025(x) {
-  return Math.round(x / 0.25) * 0.25;
-}
-
+/** Prioridad exacta pedida:
+ * 1) profile.next.weightKg
+ * 2) default de rutina/ejercicio en JSON (initialRecord.weightKg)
+ * 3) profile.last.weightKg
+ * 4) último set histórico
+ * 5) 0
+ */
 export function getInitialWeightForExercise(exId, routineKey, data) {
   const prof = data?.profileByExerciseId?.[exId];
   if (Number.isFinite(prof?.next?.weightKg)) return round025(prof.next.weightKg);
 
-  const routineDefault = getRoutineBaseDefaults(routineKey, exId);
-  if (Number.isFinite(routineDefault)) return round025(routineDefault);
+  const rdef = getRoutineBaseDefaults(routineKey, exId);
+  if (Number.isFinite(rdef)) return round025(rdef);
 
   if (Number.isFinite(prof?.last?.weightKg)) return round025(prof.last.weightKg);
 
-  const lastSet = getLastUsedSetForExercise(exId, data?.sessions || []);
-  if (Number.isFinite(lastSet?.weightKg)) return round025(lastSet.weightKg);
+  const last = getLastUsedSetForExercise(exId, data?.sessions || []);
+  if (Number.isFinite(last?.weightKg)) return round025(last.weightKg);
 
   const exDef = getExerciseDefaults(exId);
   if (Number.isFinite(exDef.initialWeightKg)) return round025(exDef.initialWeightKg);
-  if (Number.isFinite(exDef.minimumWeightKg)) return round025(exDef.minimumWeightKg);
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- derive routine and exercise default weights from JSON repo
- refine initial weight resolution and rounding utilities
- stabilize TodayTab state, handle alternatives without mutating session

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a66c32fa90832f80ef32d8e451bb1f