### PR TITLE
chore: unify exercises repo JSON imports

### DIFF
--- a/src/lib/defaultUserRoutines.js
+++ b/src/lib/defaultUserRoutines.js
@@ -1,4 +1,4 @@
-import repo from '../data/exercisesRepo.json' with { type: 'json' };
+import repo from '../data/exercisesRepo.json';
 
 /**
  * Devuelve un objeto { [routineKey]: string[] } clonado desde repo.routinesIndex.

--- a/src/lib/migrations.js
+++ b/src/lib/migrations.js
@@ -1,4 +1,4 @@
-import repo from '../data/exercisesRepo.json' with { type: 'json' };
+import repo from '../data/exercisesRepo.json';
 import { getTemplateRoutineKeys, normalizeName } from './repoAdapter.js';
 
 function simpleHash(str) {

--- a/src/lib/repo.js
+++ b/src/lib/repo.js
@@ -1,11 +1,11 @@
-import repoJson from '../data/exercisesRepo.json' with { type: 'json' };
+import repo from '../data/exercisesRepo.json';
 
 /**
  * Load the exercises repository.
  * @returns {object} Repository data
  */
 export function loadRepo() {
-  return repoJson;
+  return repo;
 }
 
 /**

--- a/src/lib/repoAdapter.js
+++ b/src/lib/repoAdapter.js
@@ -1,4 +1,4 @@
-import repo from '../data/exercisesRepo.json' with { type: 'json' };
+import repo from '../data/exercisesRepo.json';
 import { loadRepo, getExercise, listRoutine, primaryGroup, findAlternatives } from '../lib/repo.js';
 export { primaryGroup, loadRepo, findAlternatives };
 


### PR DESCRIPTION
## Summary
- load exercisesRepo.json via default imports without JSON assertions
- standardize repo.json usage in helpers

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68a73482950c832f8aa2a3a08e97754d