### PR TITLE
Add zod validation and LS migration framework

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "node src/lib/__tests__/repoAdapter.smoke.test.js && tsx src/lib/__tests__/migrations.test.ts"
   },
   "dependencies": {
     "lucide-react": "^0.539.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "recharts": "^3.1.2"
+    "recharts": "^3.1.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",
@@ -26,6 +28,7 @@
     "globals": "^16.3.0",
     "rollup-plugin-visualizer": "^6.0.3",
     "vite": "^7.1.0",
-    "vite-plugin-pwa": "^1.0.2"
+    "vite-plugin-pwa": "^1.0.2",
+    "tsx": "^4.16.2"
   }
 }

--- a/src/lib/__tests__/migrations.test.ts
+++ b/src/lib/__tests__/migrations.test.ts
@@ -1,0 +1,21 @@
+import { migrate } from '../migrations';
+
+const v4 = {
+  version: 4,
+  routines: [
+    { name: 'Test', exercises: [
+      { name: 'Belt squat cuádriceps', mode: 'reps', targetSets: 1, targetReps: 8 },
+      { name: 'Movimiento misterioso', mode: 'reps', targetSets: 1, targetReps: 10 },
+    ] }
+  ],
+  sessions: [],
+  profileByExerciseId: {},
+};
+
+const { state } = migrate(v4);
+console.assert(state.version === 5, 'version should be 5 after migration');
+const firstKey = Object.keys(state.userRoutinesIndex)[0];
+console.assert(Array.isArray(state.userRoutinesIndex[firstKey]), 'userRoutinesIndex should have arrays');
+
+console.log('migrations tests passed');
+

--- a/src/lib/migrations.ts
+++ b/src/lib/migrations.ts
@@ -1,0 +1,30 @@
+import { migrateToTemplates } from './migrations.js';
+
+/**
+ * Migrate persisted state to the latest version.
+ * @param {any} prevState
+ * @returns {{ state: any, warnings: string[] }}
+ */
+export function migrate(prevState: any = {}) {
+  let state = { ...prevState };
+  const warnings: string[] = [];
+  let v = state.version || 0;
+
+  switch (v) {
+    case 4:
+      state = migrateToTemplates(state);
+      warnings.push('migrated 4→5');
+      v = 5;
+      // fallthrough to check next migrations
+    case 5:
+      // placeholder for future migration to v6
+      break;
+    default:
+      break;
+  }
+
+  return { state, warnings };
+}
+
+export default migrate;
+

--- a/src/lib/schema.ts
+++ b/src/lib/schema.ts
@@ -1,0 +1,96 @@
+import { z } from 'zod';
+
+// Settings
+export const settingsSchema = z.object({
+  unit: z.enum(['kg', 'lb']),
+  defaultRestSec: z.number().finite(),
+  sound: z.boolean(),
+  vibration: z.boolean(),
+  theme: z.enum(['system', 'light', 'dark']),
+}).passthrough();
+
+// Workout set within a session
+const setSchema = z.object({
+  id: z.string(),
+  exerciseId: z.string(),
+  exerciseName: z.string().optional(),
+  mode: z.string(),
+  reps: z.number().finite().optional(),
+  weightKg: z.number().finite().optional(),
+  rpe: z.number().finite().optional(),
+  rir: z.number().finite().optional(),
+  tempo: z.string().optional(),
+  at: z.number().int(),
+  adhoc: z.boolean().optional(),
+  drop: z.boolean().optional(),
+}).passthrough();
+
+// Training session
+export const sessionSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  dateISO: z.string(),
+  routineKey: z.string().optional(),
+  sets: z.array(setSchema).optional(),
+  durationSec: z.number().finite().optional(),
+  distanceKm: z.number().finite().optional(),
+  totalVolume: z.number().finite().optional(),
+}).passthrough();
+
+export const sessionsSchema = z.array(sessionSchema);
+
+// Routine exercises
+const routineExerciseSchema = z.object({
+  id: z.string().optional(),
+  name: z.string(),
+  mode: z.string(),
+  targetSets: z.number().finite().optional(),
+  targetReps: z.number().finite().optional(),
+  targetRepsRange: z.string().optional(),
+  targetTimeSec: z.number().finite().optional(),
+  restSec: z.number().finite().optional(),
+}).passthrough();
+
+// Routine
+export const routineSchema = z.object({
+  name: z.string(),
+  exercises: z.array(routineExerciseSchema),
+}).passthrough();
+
+export const routinesSchema = z.array(routineSchema);
+
+// Profiles by exercise id
+export const profileByExerciseIdSchema = z.record(z.object({
+  last: z.object({
+    weightKg: z.number().finite().optional(),
+    reps: z.number().finite().optional(),
+    rir: z.number().finite().optional(),
+    dateISO: z.string().optional(),
+    setup: z.string().optional(),
+  }).partial().optional(),
+  next: z.object({
+    weightKg: z.number().finite().optional(),
+    reps: z.number().finite().optional(),
+    rir: z.number().finite().optional(),
+    dateISO: z.string().optional(),
+    setup: z.string().optional(),
+  }).partial().optional(),
+}).passthrough());
+
+// User routines index
+export const userRoutinesIndexSchema = z.record(z.array(z.string()));
+
+// Entire data blob
+export const dataSchema = z.object({
+  version: z.number().int().optional(),
+  settings: settingsSchema,
+  sessions: sessionsSchema,
+  routines: routinesSchema.optional(),
+  profileByExerciseId: profileByExerciseIdSchema,
+  userRoutinesIndex: userRoutinesIndexSchema.optional(),
+  customExercisesById: z.record(z.any()).optional(),
+  customRoutineNames: z.record(z.string()).optional(),
+}).passthrough();
+
+export default dataSchema;
+


### PR DESCRIPTION
## Summary
- introduce Zod schemas for settings, sessions, routines and related data
- migrate persisted state using version switch (4→5) with v6 stub
- sanitize imported backups and add migration smoke tests

## Testing
- `npm run lint`
- `npm test` *(fails: Module "file:///workspace/nicofit2/src/data/exercisesRepo.json" needs an import attribute of type "json"; dependencies couldn't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7392b3984832fa5e472bb21327f30