### PR TITLE
Refactor tabs into feature modules and extract workout hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "node src/lib/__tests__/analytics.test.js && node src/lib/__tests__/repoAdapter.smoke.test.js && node src/lib/__tests__/catalog.integrity.test.js && tsx src/lib/__tests__/migrations.test.ts && node src/lib/__tests__/storage.integration.test.js && tsx src/lib/__tests__/progression.test.ts"
+    "test": "node src/lib/__tests__/analytics.test.js && node src/lib/__tests__/repoAdapter.smoke.test.js && node src/lib/__tests__/catalog.integrity.test.js && tsx src/lib/__tests__/migrations.test.ts && node src/lib/__tests__/storage.integration.test.js && tsx src/lib/__tests__/progression.test.ts && tsx src/features/workout/__tests__/mainFlow.smoke.test.js"
   },
   "dependencies": {
     "lucide-react": "^0.539.0",

--- a/src/features/history/HistoryContainer.jsx
+++ b/src/features/history/HistoryContainer.jsx
@@ -1,0 +1,5 @@
+import HistoryView from "./HistoryView.jsx";
+
+export default function HistoryContainer(props) {
+  return <HistoryView {...props} />;
+}

--- a/src/features/history/HistoryView.jsx
+++ b/src/features/history/HistoryView.jsx
@@ -1,0 +1,339 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { BarChart, Bar, CartesianGrid, Legend, LineChart, Line, PieChart, Pie, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
+import { Trash2 } from "lucide-react";
+import { freqDaysByGroup, heatmapWeekGroup, validSet } from "../../lib/analytics.js";
+import { loadRepo } from "../../lib/repoAdapter.js";
+import { Card, Button, IconButton } from "../../ui.jsx";
+import { e1RM, fmtTime, toDisplayWeight } from "../../lib/metrics.ts";
+
+const repo = loadRepo();
+
+const GROUP_COLORS = { pecho: "#EF4444", espalda: "#3B82F6", pierna: "#10B981", hombro: "#F59E0B", brazo: "#8B5CF6", core: "#06B6D4", otros: "#9CA3AF" };
+
+function HeatmapWeekGroup({ data }) {
+  const max = Math.max(...Object.values(data.values).flatMap((row) => Object.values(row)));
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-xs">
+        <thead>
+          <tr>
+            <th className="p-1 text-left">Semana</th>
+            {data.groups.map((g) => (
+              <th key={g} className="p-1 text-center whitespace-nowrap">{g}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.weeks.map((w) => (
+            <tr key={w}>
+              <td className="p-1 whitespace-nowrap">{w}</td>
+              {data.groups.map((g) => {
+                const v = data.values[w][g] || 0;
+                const bg = v ? GROUP_COLORS[g] : "transparent";
+                const opacity = max ? v / max : 0;
+                return <td key={g} style={{ background: bg, opacity }} className="w-6 h-6" title={`${v}`}></td>;
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function prsRecientes(sessions, routines, days = 30, routineKey = "all") {
+  const exName = new Map();
+  for (const r of routines) {
+    for (const ex of r.exercises) exName.set(ex.id, ex.name);
+  }
+  const sorted = [...sessions]
+    .filter((s) => s.type === "strength" && (routineKey === "all" || s.routineKey === routineKey))
+    .sort((a, b) => new Date(a.dateISO) - new Date(b.dateISO));
+  const bestE1 = new Map();
+  const bestVol = new Map();
+  const bestReps = new Map();
+  const res = [];
+  const since = Date.now() - days * 24 * 3600 * 1000;
+  for (const s of sorted) {
+    const t = new Date(s.dateISO).getTime();
+    for (const st of s.sets || []) {
+      if (st.mode === "time") continue;
+      const id = st.exerciseId;
+      const name = exName.get(id) || "Ejercicio";
+      const vol = (st.weightKg || 0) * (st.reps || 0);
+      const e1 = e1RM(st.weightKg, st.reps);
+      const reps = st.reps || 0;
+      if (e1 > (bestE1.get(id) || 0)) {
+        if (t >= since) res.push({ id: `${st.id}-e1`, name, metric: "e1RM", dateISO: s.dateISO });
+        bestE1.set(id, e1);
+      }
+      if (vol > (bestVol.get(id) || 0)) {
+        if (t >= since) res.push({ id: `${st.id}-vol`, name, metric: "volumen", dateISO: s.dateISO });
+        bestVol.set(id, vol);
+      }
+      if (reps > (bestReps.get(id) || 0)) {
+        if (t >= since) res.push({ id: `${st.id}-reps`, name, metric: "+reps", dateISO: s.dateISO });
+        bestReps.set(id, reps);
+      }
+    }
+  }
+  return res.sort((a, b) => new Date(b.dateISO) - new Date(a.dateISO)).slice(0, 5);
+}
+
+export default function HistoryTab({ sessions, routines, perExerciseHistory, weeklyVolume, unit, deleteSession, setTab, exercisesById, goalProgress, adherence, streak, missed }) {
+  const [exId, setExId] = useState("");
+  const [range, setRange] = useState("30");
+  const [routineFilter, setRoutineFilter] = useState("all");
+  const allExercises = routines.flatMap((r) => r.exercises);
+  useEffect(() => { if (!exId && allExercises[0]) setExId(allExercises[0].id); }, [allExercises, exId]);
+
+  const days = parseInt(range, 10);
+  const filteredSessions = useMemo(() => {
+    const since = Date.now() - days * 24 * 3600 * 1000;
+    return sessions.filter(
+      (s) =>
+        new Date(s.dateISO).getTime() >= since &&
+        s.type === "strength" &&
+        (routineFilter === "all" || s.routineKey === routineFilter)
+    );
+  }, [sessions, days, routineFilter]);
+
+  const totalSesiones = filteredSessions.length;
+  const volumen4Semanas = useMemo(() => {
+    const since = Date.now() - 28 * 24 * 3600 * 1000;
+    return sessions
+      .filter(
+        (s) =>
+          s.type === "strength" &&
+          new Date(s.dateISO).getTime() >= since &&
+          (routineFilter === "all" || s.routineKey === routineFilter)
+      )
+      .reduce((a, s) => a + (s.totalVolume || 0), 0);
+  }, [sessions, routineFilter]);
+  const prsUltimas4 = useMemo(() => {
+    const best = new Map();
+    let prs = 0;
+    const since = Date.now() - 28 * 24 * 3600 * 1000;
+    for (const s of sessions.filter((x) => x.type === "strength" && (routineFilter === "all" || x.routineKey === routineFilter))) {
+      for (const st of s.sets || []) {
+        if (st.mode === "time") continue;
+        const e1 = e1RM(st.weightKg, st.reps);
+        const b = best.get(st.exerciseId) || 0;
+        if (e1 > b && new Date(s.dateISO).getTime() >= since) prs++;
+        best.set(st.exerciseId, Math.max(b, e1));
+      }
+    }
+    return prs;
+  }, [sessions, routineFilter]);
+
+  const chartData = useMemo(() => {
+    const since = Date.now() - days * 24 * 3600 * 1000;
+    return (perExerciseHistory.get(exId) || []).filter((d) => {
+      const t = new Date(d.date).getTime();
+      return t >= since && Number.isFinite(d.oneRM);
+    });
+  }, [perExerciseHistory, exId, days]);
+
+  const weekly8 = useMemo(() => (weeklyVolume || []).slice(-8).filter((w) => Number.isFinite(w.volume)), [weeklyVolume]);
+
+  const freq = useMemo(() => {
+    const to = new Date();
+    const from = new Date(to.getTime() - days * 24 * 3600 * 1000);
+    return freqDaysByGroup(filteredSessions, repo, { from, to, routineFilter: routineFilter === "all" ? undefined : routineFilter });
+  }, [filteredSessions, days, routineFilter]);
+  const freqClean = useMemo(() => freq.filter((f) => Number.isFinite(f.days) && f.days > 0), [freq]);
+  const hmap = useMemo(() => {
+    const to = new Date();
+    const from = new Date(to.getTime() - days * 24 * 3600 * 1000);
+    return heatmapWeekGroup(filteredSessions, repo, { from, to, routineFilter: routineFilter === "all" ? undefined : routineFilter });
+  }, [filteredSessions, days, routineFilter]);
+  const prs = useMemo(() => prsRecientes(filteredSessions, routines, days, routineFilter), [filteredSessions, routines, days, routineFilter]);
+
+  const weeklyMetrics = [
+    { key: "streak", label: "Racha", value: `${streak || 0} días`, ok: (streak || 0) >= 2 },
+    { key: "adherence", label: "Adherencia", value: `${adherence || 0}%`, ok: (adherence || 0) >= 80 },
+    {
+      key: "goal",
+      label: "Meta semanal",
+      value: `${Math.round((goalProgress?.sessions?.progress || 0) * 100)}% sesiones`,
+      ok: Boolean(goalProgress?.sessions?.ok),
+    },
+    { key: "missed", label: "Sesiones pendientes", value: String(missed || 0), ok: (missed || 0) === 0 },
+  ];
+
+  const topE1RM = useMemo(() => {
+    const best = new Map();
+    for (const s of filteredSessions) {
+      for (const st of s.sets || []) {
+        if (!validSet(st)) continue;
+        const e1 = Math.round(st.weightKg * (1 + st.reps / 30));
+        const prev = best.get(st.exerciseId) || 0;
+        if (e1 > prev) best.set(st.exerciseId, e1);
+      }
+    }
+    return [...best.entries()]
+      .map(([id, oneRM]) => ({ id, oneRM, name: exercisesById[id]?.name || "Ejercicio" }))
+      .filter((r) => Number.isFinite(r.oneRM) && r.oneRM > 0)
+      .sort((a, b) => b.oneRM - a.oneRM)
+      .slice(0, 5);
+  }, [filteredSessions, exercisesById]);
+
+  return (
+    <div className="space-y-4">
+      <Card className="p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-lg font-semibold">Resumen</h2>
+        </div>
+        <div className="flex items-center gap-2 mb-3">
+          <select value={range} onChange={(e) => setRange(e.target.value)} className="px-3 py-2 rounded-xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
+            <option value="30">30 días</option>
+            <option value="90">90 días</option>
+            <option value="180">180 días</option>
+          </select>
+          <select value={routineFilter} onChange={(e) => setRoutineFilter(e.target.value)} className="px-3 py-2 rounded-xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
+            <option value="all">Todas las rutinas</option>
+            {routines.map((r) => (
+              <option key={r.id} value={r.id}>{r.name}</option>
+            ))}
+          </select>
+        </div>
+        <div className="grid grid-cols-3 gap-2 mb-3">
+          <Card className="p-3 text-center"><div className="text-xs text-zinc-500">Sesiones ({range}d)</div><div className="text-lg font-semibold">{totalSesiones}</div></Card>
+          <Card className="p-3 text-center"><div className="text-xs text-zinc-500">Volumen (4 sem)</div><div className="text-lg font-semibold">{Math.round(volumen4Semanas)} kg·rep</div></Card>
+          <Card className="p-3 text-center"><div className="text-xs text-zinc-500">PRs (4 sem)</div><div className="text-lg font-semibold">{prsUltimas4}</div></Card>
+        </div>
+        <div className="grid grid-cols-2 gap-2 mb-3">
+          {weeklyMetrics.map((metric) => (
+            <Card key={metric.key} className={`p-3 border ${metric.ok ? "border-emerald-300" : "border-amber-300"}`}>
+              <div className="flex items-center justify-between text-xs text-zinc-500">
+                <span>{metric.label}</span>
+                <span className={metric.ok ? "text-emerald-600" : "text-amber-600"}>{metric.ok ? "ok" : "alerta"}</span>
+              </div>
+              <div className="text-lg font-semibold">{metric.value}</div>
+            </Card>
+          ))}
+        </div>
+        {weekly8.length === 0 ? (
+          <div className="h-40 flex items-center justify-center text-sm text-zinc-500">Sin datos aún</div>
+        ) : (
+          <div className="h-40">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={weekly8}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="week" hide />
+                <Tooltip formatter={(v) => `${Math.round(v)} kg·rep`} labelFormatter={(l) => `Semana ${l}`} />
+                <Bar dataKey="volume" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </Card>
+
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-2">Frecuencia por grupo (días)</h2>
+        {freqClean.length === 0 ? (
+          <div className="h-48 flex items-center justify-center text-sm text-zinc-500">Sin datos en este rango</div>
+        ) : (
+          <div className="h-48">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={freqClean} dataKey="days" nameKey="group" labelLine={false} label={({ percent }) => `${Math.round(percent * 100)}%`}>
+                  {freqClean.map((d) => (
+                    <Cell key={d.group} fill={GROUP_COLORS[d.group]} />
+                  ))}
+                </Pie>
+                <Tooltip formatter={(v, name, props) => `${props?.payload?.group} — ${v} días`} />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+      </Card>
+
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-2">Volumen semanal por grupo</h2>
+        {hmap.weeks.length === 0 || hmap.groups.length === 0 ? (
+          <div className="h-48 flex items-center justify-center text-sm text-zinc-500">Sin datos en este rango</div>
+        ) : (
+          <HeatmapWeekGroup data={hmap} />
+        )}
+      </Card>
+
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-2">PRs recientes</h2>
+        <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 divide-y">
+          {prs.map((pr) => (
+            <div key={pr.id} className="flex justify-between px-3 py-2 text-sm">
+              <span className="truncate">{pr.name}</span>
+              <span className="text-xs text-zinc-500">{pr.metric} · {new Date(pr.dateISO).toLocaleDateString()}</span>
+            </div>
+          ))}
+          {prs.length === 0 && <div className="px-3 py-2 text-sm text-zinc-500">Sin PRs.</div>}
+        </div>
+      </Card>
+
+      <Card className="p-4">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-lg font-semibold">1RM estimada por ejercicio</h2>
+          <select value={exId} onChange={(e) => setExId(e.target.value)} className="px-3 py-2 rounded-xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
+            {allExercises.map((e) => (
+              <option key={e.id} value={e.id}>{e.name}</option>
+            ))}
+          </select>
+        </div>
+        {chartData.length === 0 ? (
+          <div className="h-40 flex items-center justify-center text-sm text-zinc-500">Sin datos en este rango</div>
+        ) : (
+          <div className="h-40">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="date" />
+                <YAxis allowDecimals={false} />
+                <Tooltip formatter={(v) => `${toDisplayWeight(Math.round(v), unit)} ${unit}`} />
+                <Line type="monotone" dataKey="oneRM" />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+
+        <div className="mt-3">
+          <h3 className="text-sm font-medium mb-1">Top 5 e1RM ({range}d)</h3>
+          <div className="rounded-xl border border-zinc-200 dark:border-zinc-800 divide-y">
+            {topE1RM.map((row) => (
+              <div key={row.id} className="flex justify-between px-3 py-2 text-sm">
+                <span className="truncate">{row.name}</span>
+                <span className="tabular-nums">{toDisplayWeight(row.oneRM, unit)} {unit}</span>
+              </div>
+            ))}
+            {topE1RM.length === 0 && <div className="px-3 py-2 text-sm text-zinc-500">Sin datos todavía.</div>}
+          </div>
+        </div>
+      </Card>
+
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-2">Sesiones</h2>
+        <div className="space-y-2">
+          {sessions.filter((s) => s.type === "strength").length === 0 && (
+            <Card className="p-3 text-sm text-zinc-500 flex items-center justify-between">
+              <span>Aún no tienes sesiones registradas.</span>
+              <Button className="text-sm" onClick={() => setTab("today")}>Iniciar sesión</Button>
+            </Card>
+          )}
+          {sessions.filter((s) => s.type === "strength").map((s) => (
+            <div key={s.id} className="flex items-center justify-between p-3 rounded-xl bg-zinc-50 dark:bg-zinc-800/50">
+              <div>
+                <div className="font-medium">{new Date(s.dateISO).toLocaleDateString()} · Fuerza</div>
+                <div className="text-xs text-zinc-500">
+                  Volumen: {Math.round(s.totalVolume || 0)} kg·rep · {fmtTime(s.durationSec || 0)}{s.kcal ? ` · ${s.kcal} kcal` : ""}
+                </div>
+              </div>
+              <IconButton onClick={() => deleteSession(s.id)} title="Eliminar sesión"><Trash2 size={16} /></IconButton>
+            </div>
+          ))}
+        </div>
+      </Card>
+    </div>
+  );
+}
+

--- a/src/features/settings/SettingsContainer.jsx
+++ b/src/features/settings/SettingsContainer.jsx
@@ -1,0 +1,5 @@
+import SettingsView from "./SettingsView.jsx";
+
+export default function SettingsContainer(props) {
+  return <SettingsView {...props} />;
+}

--- a/src/features/settings/SettingsView.jsx
+++ b/src/features/settings/SettingsView.jsx
@@ -1,0 +1,211 @@
+import React, { useState } from "react";
+import { Download, Upload } from "lucide-react";
+import { migrate } from "../../lib/migrateState.js";
+import { dataSchema } from "../../lib/schema.ts";
+import { Card, Button, Input, Label } from "../../ui.jsx";
+import { e1RM, todayISO } from "../../lib/metrics.ts";
+
+const escapeHtml = (s) => String(s).replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+export default function SettingsTab({ data, setData, syncStatus }) {
+  const [fileErr, setFileErr] = useState("");
+  const [calc, setCalc] = useState({ weight: "", reps: "", percent: "85" });
+  const [showPolicy, setShowPolicy] = useState(false);
+
+  const onExport = () => {
+    const json = JSON.stringify(data, null, 2);
+    try {
+      const blob = new Blob([json], { type: "application/json" });
+      const URL_ = window.URL || URL;
+      const url = URL_?.createObjectURL?.(blob);
+      if (url) {
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `nicofit_backup_${todayISO()}.json`;
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        URL_?.revokeObjectURL?.(url);
+        return;
+      }
+    } catch {}
+    try {
+      navigator.clipboard?.writeText(json);
+      alert("No se pudo descargar archivo. Copié el JSON al portapapeles.");
+      return;
+    } catch {}
+    try {
+      const w = window.open();
+      if (w) {
+        w.document.write(`<pre style="white-space:pre-wrap;word-break:break-word;">${escapeHtml(json)}</pre>`);
+        w.document.close();
+        return;
+      }
+    } catch {}
+    alert("Export no disponible en este entorno. Copia manual desde la consola.");
+  };
+
+  const sanitizeImported = (data) => {
+    const keys = new Set(['name', 'notes', 'exerciseName', 'setup']);
+    const walk = (val) => {
+      if (Array.isArray(val)) val.forEach(walk);
+      else if (val && typeof val === 'object') {
+        Object.keys(val).forEach(k => {
+          const v = val[k];
+          if (typeof v === 'string' && keys.has(k)) val[k] = escapeHtml(v);
+          else walk(v);
+        });
+      }
+    };
+    const clone = structuredClone(data);
+    walk(clone);
+    return clone;
+  };
+
+  const onImport = (e) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      try {
+        const obj = JSON.parse(reader.result);
+        const parsed = dataSchema.safeParse(obj);
+        if (!parsed.success) throw new Error('invalid');
+        const { state } = migrate(parsed.data);
+        const sanitized = sanitizeImported(state);
+        setData(sanitized);
+        setFileErr('');
+        alert('Datos importados ✔');
+      } catch (err) {
+        console.warn(err);
+        setFileErr('No se pudo importar (JSON inválido)');
+      }
+    };
+    reader.readAsText(f);
+  };
+
+  const oneRm = (() => { const w = parseFloat(calc.weight || 0); const r = parseInt(calc.reps || 0, 10); return e1RM(w, r); })();
+  const targetLoad = (() => { const p = parseFloat(calc.percent || 0) / 100; return Math.round(oneRm * p); })();
+
+  return (
+    <div className="space-y-4">
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-2">Preferencias</h2>
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <Label>Unidades</Label>
+            <select value={data.settings.unit} onChange={(e) => setData((d) => ({ ...d, settings: { ...d.settings, unit: e.target.value } }))} className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
+              <option value="kg">kg</option>
+              <option value="lb">lb</option>
+            </select>
+          </div>
+          <div>
+            <Label>Descanso (seg)</Label>
+            <Input type="number" value={data.settings.defaultRestSec} onChange={(e) => setData((d) => ({ ...d, settings: { ...d.settings, defaultRestSec: parseInt(e.target.value || 0, 10) } }))} />
+          </div>
+          <div>
+            <Label>Sonido</Label>
+            <select value={String(data.settings.sound)} onChange={(e) => setData((d) => ({ ...d, settings: { ...d.settings, sound: e.target.value === 'true' } }))} className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
+              <option value="true">On</option>
+              <option value="false">Off</option>
+            </select>
+          </div>
+          <div>
+            <Label>Vibración</Label>
+            <select value={String(data.settings.vibration)} onChange={(e) => setData((d) => ({ ...d, settings: { ...d.settings, vibration: e.target.value === 'true' } }))} className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
+              <option value="true">On</option>
+              <option value="false">Off</option>
+            </select>
+          </div>
+          <div>
+            <Label>Tema</Label>
+            <select value={data.settings.theme} onChange={(e) => setData((d) => ({ ...d, settings: { ...d.settings, theme: e.target.value } }))} className="mt-1 w-full px-3 py-2 rounded-xl bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800">
+              <option value="system">Sistema</option>
+              <option value="light">Claro</option>
+              <option value="dark">Oscuro</option>
+            </select>
+          </div>
+        </div>
+        <div className="mt-3 text-sm text-zinc-600 dark:text-zinc-400">Versión: <span className="font-semibold">v{data.version || 1}</span></div>
+      </Card>
+
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-2">Metas semanales</h2>
+        <div className="grid grid-cols-3 gap-2">
+          <div>
+            <Label>Sesiones</Label>
+            <Input type="number" min="0" value={data.settings?.weeklyGoals?.sessions ?? 0} onChange={(e) => setData((d) => ({ ...d, settings: { ...d.settings, weeklyGoals: { ...(d.settings?.weeklyGoals || {}), sessions: Math.max(0, parseInt(e.target.value || 0, 10)) } } }))} />
+          </div>
+          <div>
+            <Label>Volumen (kg·rep)</Label>
+            <Input type="number" min="0" step="100" value={data.settings?.weeklyGoals?.volume ?? 0} onChange={(e) => setData((d) => ({ ...d, settings: { ...d.settings, weeklyGoals: { ...(d.settings?.weeklyGoals || {}), volume: Math.max(0, parseInt(e.target.value || 0, 10)) } } }))} />
+          </div>
+          <div>
+            <Label>Cardio (min)</Label>
+            <Input type="number" min="0" value={data.settings?.weeklyGoals?.cardio ?? 0} onChange={(e) => setData((d) => ({ ...d, settings: { ...d.settings, weeklyGoals: { ...(d.settings?.weeklyGoals || {}), cardio: Math.max(0, parseInt(e.target.value || 0, 10)) } } }))} />
+          </div>
+        </div>
+      </Card>
+
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-2">Calculadora 1RM</h2>
+        <div className="grid grid-cols-3 gap-2 items-end">
+          <div>
+            <Label>Peso (kg)</Label>
+            <Input type="number" step="0.25" inputMode="decimal" value={calc.weight} onChange={(e) => setCalc((c) => ({ ...c, weight: e.target.value }))} />
+          </div>
+          <div>
+            <Label>Reps</Label>
+            <Input type="number" value={calc.reps} onChange={(e) => setCalc((c) => ({ ...c, reps: e.target.value }))} />
+          </div>
+          <div>
+            <Label>% objetivo</Label>
+            <Input type="number" value={calc.percent} onChange={(e) => setCalc((c) => ({ ...c, percent: e.target.value }))} />
+          </div>
+        </div>
+        <div className="mt-2 text-sm text-zinc-600 dark:text-zinc-400">1RM estimada: <span className="font-semibold">{oneRm || 0} kg</span> · Carga al {calc.percent}%: <span className="font-semibold">{Number.isFinite(targetLoad) ? targetLoad : 0} kg</span></div>
+      </Card>
+
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-2">Datos y backup</h2>
+        <div className="flex items-center gap-2">
+          <Button onClick={onExport} className="text-sm"><Download size={16} className="inline mr-1" /> Exportar backup</Button>
+          <label className="px-4 py-2 rounded-2xl bg-zinc-900 text-white dark:bg-zinc-100 dark:text-zinc-900 cursor-pointer text-sm">
+            <Upload size={16} className="inline mr-1" /> Importar backup
+            <input type="file" accept="application/json" onChange={onImport} className="hidden" />
+          </label>
+          <Button className="text-sm" onClick={() => setShowPolicy(true)}>Política de datos</Button>
+        </div>
+        {fileErr && <div className="text-sm text-rose-500 mt-2">{fileErr}</div>}
+        <p className="text-xs text-zinc-500 mt-2">La sincronización en la nube es primaria. Exportar/Importar queda como respaldo manual.</p>
+        <p className="text-xs text-zinc-500 mt-1">Última sincronización: {syncStatus?.lastSyncedAt ? new Date(syncStatus.lastSyncedAt).toLocaleString() : "Sin sincronizar"} · Estado: {syncStatus?.phase || "idle"}</p>
+      </Card>
+
+      <Card className="p-4">
+        <h2 className="text-lg font-semibold mb-1">Tips</h2>
+        <ul className="text-sm text-zinc-600 dark:text-zinc-400 list-disc ml-5 space-y-1">
+          <li>Agrega NicoFit a tu pantalla de inicio en iPhone para abrirlo como app.</li>
+          <li>Define descansos por ejercicio desde la rutina si quieres más control.</li>
+          <li>El peso se autocompleta con el sugerido; ajústalo en cada serie si hace falta.</li>
+        </ul>
+      </Card>
+
+      {showPolicy && (
+        <div className="fixed inset-0 z-50 grid place-items-center bg-black/40">
+          <Card className="max-w-sm w-[90%] p-4">
+            <h3 className="text-lg font-semibold mb-2">Política de datos</h3>
+            <p className="text-sm text-zinc-600 dark:text-zinc-300">
+              Los datos se guardan localmente como caché offline y también se sincronizan por usuario con backend.
+              Puedes exportarlos/importarlos como backup secundario.
+              Si activas PWA/notificaciones, se instalan archivos en caché para funcionar offline.
+            </p>
+            <div className="mt-3 flex justify-end">
+              <Button className="text-sm" onClick={() => setShowPolicy(false)}>Cerrar</Button>
+            </div>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/features/workout/WorkoutContainer.jsx
+++ b/src/features/workout/WorkoutContainer.jsx
@@ -1,0 +1,5 @@
+import WorkoutView from "./WorkoutView.jsx";
+
+export default function WorkoutContainer({ tab, renderToday, renderRoutines }) {
+  return <WorkoutView tab={tab} today={renderToday()} routines={renderRoutines()} />;
+}

--- a/src/features/workout/WorkoutView.jsx
+++ b/src/features/workout/WorkoutView.jsx
@@ -1,0 +1,5 @@
+export default function WorkoutView({ tab, today, routines }) {
+  if (tab === "today") return today;
+  if (tab === "routines") return routines;
+  return null;
+}

--- a/src/features/workout/__tests__/mainFlow.smoke.test.js
+++ b/src/features/workout/__tests__/mainFlow.smoke.test.js
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import { buildFinishedSession } from "../mainFlow.js";
+import { e1RM, fmtTime, fromDisplayToKg, toDisplayWeight } from "../../../lib/metrics.js";
+
+const activeSession = {
+  id: "s1",
+  type: "strength",
+  routineKey: "a",
+  sets: [
+    { mode: "reps", weightKg: 100, reps: 5 },
+    { mode: "time", weightKg: 0, reps: 0 },
+    { mode: "reps", weightKg: 60, reps: 10 },
+  ],
+};
+
+const finished = buildFinishedSession(activeSession, 1800, 400);
+assert.equal(finished.totalVolume, 1100);
+assert.equal(finished.durationSec, 1800);
+assert.equal(e1RM(100, 5), 117);
+assert.equal(fmtTime(125), "2:05");
+assert.equal(toDisplayWeight(100, "lb"), 220.5);
+assert.equal(fromDisplayToKg(220.5, "lb"), 100);
+
+console.log("main flow smoke test passed");

--- a/src/features/workout/mainFlow.js
+++ b/src/features/workout/mainFlow.js
@@ -1,0 +1,4 @@
+export function buildFinishedSession(activeSession, durationSec, kcal) {
+  const totalVol = (activeSession.sets || []).reduce((acc, setItem) => acc + (setItem.mode === "time" ? 0 : setItem.weightKg * setItem.reps), 0);
+  return { ...activeSession, durationSec, totalVolume: totalVol, kcal };
+}

--- a/src/hooks/useActiveSession.js
+++ b/src/hooks/useActiveSession.js
@@ -1,0 +1,47 @@
+import { useRef, useState } from "react";
+import { toISODate } from "../lib/metrics.ts";
+import { buildFinishedSession } from "../features/workout/mainFlow.js";
+
+const uid = () => Math.random().toString(36).slice(2) + Date.now().toString(36);
+
+export function useActiveSession({ setData }) {
+  const [activeSession, setActiveSession] = useState(null);
+  const [prFlash, setPrFlash] = useState("");
+  const lastActionRef = useRef({ exId: null, added: 0, prevCompleted: false, undo: null });
+
+  const startStrength = (routineKey) => {
+    if (!routineKey) return;
+    setActiveSession({ id: uid(), type: "strength", dateISO: toISODate(), routineKey, sets: [], startedAt: Date.now() });
+  };
+
+  const finishStrength = () => {
+    if (!activeSession) return;
+    const autoDur = Math.max(1, Math.floor((Date.now() - activeSession.startedAt) / 1000));
+    let inputDur = prompt("Tiempo total de la rutina (minutos). Deja vacío para usar automático", String(Math.round(autoDur / 60)));
+    let durationSec = autoDur;
+    if (inputDur && !Number.isNaN(parseFloat(inputDur))) durationSec = Math.max(60, Math.round(parseFloat(inputDur) * 60));
+    let kcalStr = prompt("Kcal quemadas (opcional)", "");
+    const kcal = kcalStr && !Number.isNaN(parseFloat(kcalStr)) ? Math.round(parseFloat(kcalStr)) : undefined;
+    const finishedSession = buildFinishedSession(activeSession, durationSec, kcal);
+    setData((d) => ({ ...d, sessions: [finishedSession, ...d.sessions] }));
+    setActiveSession(null);
+  };
+
+  const undoLast = () => {
+    setActiveSession((s) => (s ? ({ ...s, sets: s.sets.slice(0, -(lastActionRef.current?.added || 0)) }) : s));
+    lastActionRef.current.undo?.();
+    lastActionRef.current = { exId: null, added: 0, prevCompleted: false, undo: null };
+    setPrFlash("");
+  };
+
+  return {
+    activeSession,
+    setActiveSession,
+    startStrength,
+    finishStrength,
+    lastActionRef,
+    prFlash,
+    setPrFlash,
+    undoLast,
+  };
+}

--- a/src/hooks/useWorkoutTimer.js
+++ b/src/hooks/useWorkoutTimer.js
@@ -1,0 +1,53 @@
+import { useCallback, useRef, useState } from "react";
+
+export function useWorkoutTimer({ soundEnabled, vibrationEnabled, onTimerDone }) {
+  const [restSec, setRestSec] = useState(0);
+  const restDeadlineRef = useRef(null);
+  const rafRef = useRef(null);
+
+  const stopRest = useCallback(() => {
+    restDeadlineRef.current = null;
+    setRestSec(0);
+    cancelAnimationFrame(rafRef.current);
+    rafRef.current = null;
+  }, []);
+
+  const loop = useCallback(() => {
+    if (!restDeadlineRef.current) {
+      rafRef.current = null;
+      return;
+    }
+
+    const msLeft = restDeadlineRef.current - performance.now();
+    const secLeft = Math.max(0, Math.ceil(msLeft / 1000));
+    setRestSec(secLeft);
+
+    if (secLeft === 0) {
+      onTimerDone?.();
+      if (vibrationEnabled && navigator.vibrate) navigator.vibrate(80);
+      if (soundEnabled) {
+        // caller can still use onTimerDone for a custom beep implementation
+      }
+      restDeadlineRef.current = null;
+    }
+
+    rafRef.current = requestAnimationFrame(loop);
+  }, [onTimerDone, soundEnabled, vibrationEnabled]);
+
+  const startRest = useCallback((seconds) => {
+    const s = Math.max(0, Number(seconds || 0));
+    if (s <= 0) {
+      stopRest();
+      return;
+    }
+
+    restDeadlineRef.current = performance.now() + s * 1000;
+    if (!rafRef.current) rafRef.current = requestAnimationFrame(loop);
+  }, [loop, stopRest]);
+
+  return {
+    restSec,
+    startRest,
+    stopRest,
+  };
+}

--- a/src/lib/metrics.js
+++ b/src/lib/metrics.js
@@ -1,0 +1,19 @@
+export const fmtTime = (sec) => {
+  const s = Math.max(0, Math.floor(sec));
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m}:${r.toString().padStart(2, "0")}`;
+};
+
+export const toISODate = (d = new Date()) => new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString();
+export const todayISO = () => toISODate().slice(0, 10);
+
+export const e1RM = (w, reps) => (w > 0 && reps > 0 ? Math.round(w * (1 + reps / 30)) : 0);
+
+export const toDisplayWeight = (val, unit) => (
+  unit === "lb" ? Math.round(val * 2.20462 * 10) / 10 : Math.round(val)
+);
+
+export const fromDisplayToKg = (val, unit) => (
+  unit === "lb" ? Math.round((val / 2.20462) * 10) / 10 : val
+);

--- a/src/lib/metrics.ts
+++ b/src/lib/metrics.ts
@@ -1,0 +1,19 @@
+export const fmtTime = (sec: number) => {
+  const s = Math.max(0, Math.floor(sec));
+  const m = Math.floor(s / 60);
+  const r = s % 60;
+  return `${m}:${r.toString().padStart(2, "0")}`;
+};
+
+export const toISODate = (d = new Date()) => new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString();
+export const todayISO = () => toISODate().slice(0, 10);
+
+export const e1RM = (w: number, reps: number) => (w > 0 && reps > 0 ? Math.round(w * (1 + reps / 30)) : 0);
+
+export const toDisplayWeight = (val: number, unit: "kg" | "lb") => (
+  unit === "lb" ? Math.round(val * 2.20462 * 10) / 10 : Math.round(val)
+);
+
+export const fromDisplayToKg = (val: number, unit: "kg" | "lb") => (
+  unit === "lb" ? Math.round((val / 2.20462) * 10) / 10 : val
+);


### PR DESCRIPTION
### Motivation

- Modularizar la UI para que `App.jsx` sea un orquestador ligero y delegue la UI por feature (workout, history, settings). 
- Extraer la lógica relacionada con la sesión activa y el temporizador de descanso a hooks reutilizables para mejorar la mantenibilidad. 
- Centralizar helpers métricos repetidos para evitar duplicación y facilitar el uso desde TS/JS. 

### Description

- Se añadieron carpetas de feature con contenedor/presentacional: `src/features/workout/*`, `src/features/history/*` y `src/features/settings/*` y se reubicaron las vistas correspondientes. 
- Se extrajeron dos hooks: `src/hooks/useActiveSession.js` (gestión de sesión: start/finish/undo/estado PR) y `src/hooks/useWorkoutTimer.js` (start/stop/loop del temporizador de descanso). 
- Se centralizaron helpers en `src/lib/metrics.ts` y se añadió un espejo JS `src/lib/metrics.js` para compatibilidad en runtime, y se actualizó el código consumidor para usar `e1RM`, `fmtTime`, `toDisplayWeight`, `fromDisplayToKg`, `todayISO`. 
- `App.jsx` fue simplificado para orquestar estado global, registrar los hooks y delegar render mediante `WorkoutContainer`, `HistoryContainer` y `SettingsContainer`. 
- Se añadió un helper de finalización de sesión `buildFinishedSession` en `src/features/workout/mainFlow.js` y un smoke test `src/features/workout/__tests__/mainFlow.smoke.test.js` que valida el flujo principal y las utilidades métricas; se actualizó el `test` script en `package.json` para incluir el nuevo test. 

### Testing

- Ejecuté `node src/features/workout/__tests__/mainFlow.smoke.test.js` y el test smoke del flujo principal pasó (`main flow smoke test passed`).
- Ejecuté `node src/lib/__tests__/analytics.test.js`, `node src/lib/__tests__/repoAdapter.smoke.test.js` y `node src/lib/__tests__/catalog.integrity.test.js` y los tres pasaron (la verificación de catálogo emitió advertencias `sample-missing` pero terminó OK).
- Intenté ejecutar `npm test` pero la ejecución completa falló en este entorno porque la herramienta `tsx` no está disponible y `npm install` no pudo completar por restricciones de registro (`403`), por lo que el script completo no pudo ejecutarse aquí.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699784e54558832fa61bab923e52e541)